### PR TITLE
Refactor: Introduce reusable layout components

### DIFF
--- a/src/components/GithubClientTester.tsx
+++ b/src/components/GithubClientTester.tsx
@@ -3,9 +3,9 @@ import { parseAsString, useQueryState } from 'nuqs'
 import { UAParser } from 'ua-parser-js'
 import { GithubApi } from '@/clients/github/api'
 import { withNuqsAdapter } from '@/components/NuqsProvider'
-import { PageTitle } from '@/components/layout/PageTitle'
 import { Button } from '@/components/ui/button'
 import { PackageService } from '@/services/PackageService'
+import { PageTitle } from '@/components/layout/PageTitle'
 
 type ApiAction =
   | 'latest-release'

--- a/src/components/GithubClientTester.tsx
+++ b/src/components/GithubClientTester.tsx
@@ -3,9 +3,9 @@ import { parseAsString, useQueryState } from 'nuqs'
 import { UAParser } from 'ua-parser-js'
 import { GithubApi } from '@/clients/github/api'
 import { withNuqsAdapter } from '@/components/NuqsProvider'
+import { PageTitle } from '@/components/layout/PageTitle'
 import { Button } from '@/components/ui/button'
 import { PackageService } from '@/services/PackageService'
-import { PageTitle } from '@/components/layout/PageTitle'
 
 type ApiAction =
   | 'latest-release'

--- a/src/components/GithubClientTester.tsx
+++ b/src/components/GithubClientTester.tsx
@@ -5,6 +5,7 @@ import { GithubApi } from '@/clients/github/api'
 import { withNuqsAdapter } from '@/components/NuqsProvider'
 import { Button } from '@/components/ui/button'
 import { PackageService } from '@/services/PackageService'
+import { PageTitle } from '@/components/layout/PageTitle'
 
 type ApiAction =
   | 'latest-release'
@@ -211,7 +212,7 @@ function _GitHubApiTester({
 
   return (
     <div className='max-w-4xl mx-auto p-4'>
-      <h1 className='text-2xl font-bold mb-6'>GitHub API Tester</h1>
+      <PageTitle>GitHub API Tester</PageTitle>
 
       <div className='bg-white p-6 rounded-lg shadow-md mb-6'>
         <div className='grid grid-cols-1 md:grid-cols-2 gap-4 mb-4'>

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,17 +1,17 @@
-import React from 'react'
+import React from 'react';
 
 interface HeroSectionProps {
-  title: string
-  subtitle: string
+  title: string;
+  subtitle: string;
 }
 
 const HeroSection: React.FC<HeroSectionProps> = ({ title, subtitle }) => {
   return (
-    <article className='typography mb-8 text-center'>
-      <h1 className='mb-0'>{title}</h1>
-      <h3 className='mt-0'>{subtitle}</h3>
+    <article className="typography mb-8 text-center">
+      <h1 className="mb-0">{title}</h1>
+      <h3 className="mt-0">{subtitle}</h3>
     </article>
-  )
-}
+  );
+};
 
-export { HeroSection }
+export { HeroSection };

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface HeroSectionProps {
+  title: string;
+  subtitle: string;
+}
+
+const HeroSection: React.FC<HeroSectionProps> = ({ title, subtitle }) => {
+  return (
+    <article className="typography mb-8 text-center">
+      <h1 className="mb-0">{title}</h1>
+      <h3 className="mt-0">{subtitle}</h3>
+    </article>
+  );
+};
+
+export { HeroSection };

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React from 'react'
 
 interface HeroSectionProps {
-  title: string;
-  subtitle: string;
+  title: string
+  subtitle: string
 }
 
 const HeroSection: React.FC<HeroSectionProps> = ({ title, subtitle }) => {
   return (
-    <article className="typography mb-8 text-center">
-      <h1 className="mb-0">{title}</h1>
-      <h3 className="mt-0">{subtitle}</h3>
+    <article className='typography mb-8 text-center'>
+      <h1 className='mb-0'>{title}</h1>
+      <h3 className='mt-0'>{subtitle}</h3>
     </article>
-  );
-};
+  )
+}
 
-export { HeroSection };
+export { HeroSection }

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React from 'react';
 
 interface PageContainerProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
 const PageContainer: React.FC<PageContainerProps> = ({ children }) => {
-  return <div className='container mx-auto p-4'>{children}</div>
-}
+  return (
+    <div className="container mx-auto p-4">
+      {children}
+    </div>
+  );
+};
 
-export { PageContainer }
+export { PageContainer };

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
+import React from 'react'
 
 interface PageContainerProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 const PageContainer: React.FC<PageContainerProps> = ({ children }) => {
-  return (
-    <div className="container mx-auto p-4">
-      {children}
-    </div>
-  );
-};
+  return <div className='container mx-auto p-4'>{children}</div>
+}
 
-export { PageContainer };
+export { PageContainer }

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface PageContainerProps {
+  children: React.ReactNode;
+}
+
+const PageContainer: React.FC<PageContainerProps> = ({ children }) => {
+  return (
+    <div className="container mx-auto p-4">
+      {children}
+    </div>
+  );
+};
+
+export { PageContainer };

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
+import React from 'react'
 
 interface PageTitleProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 const PageTitle: React.FC<PageTitleProps> = ({ children }) => {
-  return (
-    <h1 className="text-2xl font-bold mb-6">
-      {children}
-    </h1>
-  );
-};
+  return <h1 className='text-2xl font-bold mb-6'>{children}</h1>
+}
 
-export { PageTitle };
+export { PageTitle }

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React from 'react';
 
 interface PageTitleProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
 const PageTitle: React.FC<PageTitleProps> = ({ children }) => {
-  return <h1 className='text-2xl font-bold mb-6'>{children}</h1>
-}
+  return (
+    <h1 className="text-2xl font-bold mb-6">
+      {children}
+    </h1>
+  );
+};
 
-export { PageTitle }
+export { PageTitle };

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface PageTitleProps {
+  children: React.ReactNode;
+}
+
+const PageTitle: React.FC<PageTitleProps> = ({ children }) => {
+  return (
+    <h1 className="text-2xl font-bold mb-6">
+      {children}
+    </h1>
+  );
+};
+
+export { PageTitle };

--- a/src/components/release/MatchTags.tsx
+++ b/src/components/release/MatchTags.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import type { IMatchResult } from '@/lib/types'
 import { Badge } from '@/components/ui/Badge'
+import type { IMatchResult } from '@/lib/types'
 
 interface MatchTagsProps {
   matchInfo: IMatchResult
@@ -11,17 +11,17 @@ export const MatchTags: React.FC<MatchTagsProps> = ({ matchInfo }) => {
   return (
     <div className='flex flex-wrap gap-1 mt-1'>
       {exact_match.map((match) => (
-        <Badge variant="success" key={`exact-${match}`}>
+        <Badge variant='success' key={`exact-${match}`}>
           {match}
         </Badge>
       ))}
       {partial_match.map((match) => (
-        <Badge variant="default" key={`partial-${match}`}>
+        <Badge variant='default' key={`partial-${match}`}>
           {match}
         </Badge>
       ))}
       {conflicts.map((match) => (
-        <Badge variant="danger" key={`conflict-${match}`}>
+        <Badge variant='danger' key={`conflict-${match}`}>
           {match}
         </Badge>
       ))}

--- a/src/components/release/MatchTags.tsx
+++ b/src/components/release/MatchTags.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { IMatchResult } from '@/lib/types'
+import { Badge } from '@/components/ui/Badge'
 
 interface MatchTagsProps {
   matchInfo: IMatchResult
@@ -10,28 +11,19 @@ export const MatchTags: React.FC<MatchTagsProps> = ({ matchInfo }) => {
   return (
     <div className='flex flex-wrap gap-1 mt-1'>
       {exact_match.map((match) => (
-        <span
-          key={`exact-${match}`}
-          className='bg-green-100 text-sm text-green-800 font-medium px-2.5 py-0.5 rounded-full border-green-800 border-2 dark:bg-green-900 dark:text-green-200 dark:border-green-200'
-        >
+        <Badge variant="success" key={`exact-${match}`}>
           {match}
-        </span>
+        </Badge>
       ))}
       {partial_match.map((match) => (
-        <span
-          key={`partial-${match}`}
-          className='bg-gray-100 text-sm text-gray-800 font-medium px-2.5 py-0.5 rounded-full border-gray-800 border-2 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-200'
-        >
+        <Badge variant="default" key={`partial-${match}`}>
           {match}
-        </span>
+        </Badge>
       ))}
       {conflicts.map((match) => (
-        <span
-          key={`conflict-${match}`}
-          className='bg-red-100 text-sm text-red-800 font-medium px-2.5 py-0.5 rounded-full border-red-800 border-2 dark:bg-red-900 dark:text-red-200 dark:border-red-200'
-        >
+        <Badge variant="danger" key={`conflict-${match}`}>
           {match}
-        </span>
+        </Badge>
       ))}
     </div>
   )

--- a/src/components/release/MatchTags.tsx
+++ b/src/components/release/MatchTags.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { Badge } from '@/components/ui/Badge'
 import type { IMatchResult } from '@/lib/types'
+import { Badge } from '@/components/ui/Badge'
 
 interface MatchTagsProps {
   matchInfo: IMatchResult
@@ -11,17 +11,17 @@ export const MatchTags: React.FC<MatchTagsProps> = ({ matchInfo }) => {
   return (
     <div className='flex flex-wrap gap-1 mt-1'>
       {exact_match.map((match) => (
-        <Badge variant='success' key={`exact-${match}`}>
+        <Badge variant="success" key={`exact-${match}`}>
           {match}
         </Badge>
       ))}
       {partial_match.map((match) => (
-        <Badge variant='default' key={`partial-${match}`}>
+        <Badge variant="default" key={`partial-${match}`}>
           {match}
         </Badge>
       ))}
       {conflicts.map((match) => (
-        <Badge variant='danger' key={`conflict-${match}`}>
+        <Badge variant="danger" key={`conflict-${match}`}>
           {match}
         </Badge>
       ))}

--- a/src/components/release/PackageCard.tsx
+++ b/src/components/release/PackageCard.tsx
@@ -1,5 +1,6 @@
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
 import { DownloadButton } from '@/components/ui/download-button'
+import { Badge } from '@/components/ui/Badge'
 import { type IMatchResult } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
@@ -32,29 +33,19 @@ export function PackageCard({ name, url, matchInfo, recommended = false }: Packa
         <CardContent className='px-4 py-2'>
           <div className='flex flex-wrap gap-2 text-sm'>
             {badges.exact_match.map((m, i) => (
-              <span
-                key={`exact-${i}`}
-                className='bg-green-50 text-green-700 px-2 py-1 rounded-full border border-green-200'
-              >
-                <span className='mr-1'>✓</span>
-                {m}
-              </span>
+              <Badge variant="success" key={`exact-${i}`}>
+                ✓ {m}
+              </Badge>
             ))}
             {badges.partial_match.map((m, i) => (
-              <span
-                key={`partial-${i}`}
-                className='bg-yellow-50 text-yellow-700 px-2 py-1 rounded-full border border-yellow-200'
-              >
+              <Badge variant="warning" key={`partial-${i}`}>
                 {m}
-              </span>
+              </Badge>
             ))}
             {badges.conflicts.map((c, i) => (
-              <span
-                key={`conflict-${i}`}
-                className='bg-red-50 text-red-700 px-2 py-1 rounded-full border border-red-200'
-              >
-                <span className='mr-1'>✗</span> {c}
-              </span>
+              <Badge variant="danger" key={`conflict-${i}`}>
+                ✗ {c}
+              </Badge>
             ))}
           </div>
         </CardContent>

--- a/src/components/release/PackageCard.tsx
+++ b/src/components/release/PackageCard.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@/components/ui/Badge'
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
 import { DownloadButton } from '@/components/ui/download-button'
+import { Badge } from '@/components/ui/Badge'
 import { type IMatchResult } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
@@ -33,17 +33,17 @@ export function PackageCard({ name, url, matchInfo, recommended = false }: Packa
         <CardContent className='px-4 py-2'>
           <div className='flex flex-wrap gap-2 text-sm'>
             {badges.exact_match.map((m, i) => (
-              <Badge variant='success' key={`exact-${i}`}>
+              <Badge variant="success" key={`exact-${i}`}>
                 ✓ {m}
               </Badge>
             ))}
             {badges.partial_match.map((m, i) => (
-              <Badge variant='warning' key={`partial-${i}`}>
+              <Badge variant="warning" key={`partial-${i}`}>
                 {m}
               </Badge>
             ))}
             {badges.conflicts.map((c, i) => (
-              <Badge variant='danger' key={`conflict-${i}`}>
+              <Badge variant="danger" key={`conflict-${i}`}>
                 ✗ {c}
               </Badge>
             ))}

--- a/src/components/release/PackageCard.tsx
+++ b/src/components/release/PackageCard.tsx
@@ -1,6 +1,6 @@
+import { Badge } from '@/components/ui/Badge'
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
 import { DownloadButton } from '@/components/ui/download-button'
-import { Badge } from '@/components/ui/Badge'
 import { type IMatchResult } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
@@ -33,17 +33,17 @@ export function PackageCard({ name, url, matchInfo, recommended = false }: Packa
         <CardContent className='px-4 py-2'>
           <div className='flex flex-wrap gap-2 text-sm'>
             {badges.exact_match.map((m, i) => (
-              <Badge variant="success" key={`exact-${i}`}>
+              <Badge variant='success' key={`exact-${i}`}>
                 ✓ {m}
               </Badge>
             ))}
             {badges.partial_match.map((m, i) => (
-              <Badge variant="warning" key={`partial-${i}`}>
+              <Badge variant='warning' key={`partial-${i}`}>
                 {m}
               </Badge>
             ))}
             {badges.conflicts.map((c, i) => (
-              <Badge variant="danger" key={`conflict-${i}`}>
+              <Badge variant='danger' key={`conflict-${i}`}>
                 ✗ {c}
               </Badge>
             ))}

--- a/src/components/search/RepoSearch.tsx
+++ b/src/components/search/RepoSearch.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { GithubResponse } from '@/clients/github/api'
 import { Card, CardHeader } from '@/components/ui/card'
-import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
+import { TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
 import { RepositoryCard } from '@/components/search/RepositoryCard'
 
 type RepoItem = GithubResponse['searchRepositories']['items'][number]

--- a/src/components/search/RepoSearch.tsx
+++ b/src/components/search/RepoSearch.tsx
@@ -1,107 +1,10 @@
 import React from 'react'
-import { Github, Star, Link as LinkIcon } from 'lucide-react'
-// Renamed Link to LinkIcon
 import type { GithubResponse } from '@/clients/github/api'
-import { ButtonLink } from '@/components/ui/button-link'
 import { Card, CardHeader } from '@/components/ui/card'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
+import { RepositoryCard } from '@/components/search/RepositoryCard'
 
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
-
-interface RepoListItemProps {
-  repo: RepoItem
-}
-
-const RepoListItem: React.FC<RepoListItemProps> = ({ repo }) => {
-  const ownerLogin = repo.owner?.login
-  const repoName = repo.name
-
-  const internalLink =
-    ownerLogin && repoName ?
-      `/user/repository?u=${encodeURIComponent(ownerLogin)}&r=${encodeURIComponent(repoName)}`
-    : '#'
-
-  return (
-    <div
-      className={cn(
-        'p-3 border rounded-md dark:border-zinc-700 bg-card', // Use card background
-        'hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors duration-150', // Hover effect like RepositoryDetail
-      )}
-    >
-      {/* Top section: Repo name, Stars, GitHub link */}
-      <div className='flex justify-between items-start gap-2 mb-2'>
-        {/* Link to internal repo page */}
-        <a
-          href={internalLink}
-          className='font-semibold hover:underline mr-2 overflow-hidden text-ellipsis whitespace-nowrap text-foreground' // Truncate long names
-          title={repo.full_name} // Add title attribute for full name on hover
-        >
-          {repo.full_name}
-        </a>
-
-        {/* Stars and GitHub Icon */}
-        <div className='flex items-center gap-2 text-sm whitespace-nowrap flex-shrink-0'>
-          <span className='flex items-center gap-1 text-muted-foreground'>
-            <Star size={14} className='fill-current text-yellow-500' />{' '}
-            {/* Use fill-current and specific color */}
-            {repo.stargazers_count?.toLocaleString() ?? 0} {/* Format numbers */}
-          </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ButtonLink
-                variant='ghost'
-                size='icon'
-                className='h-6 w-6 text-muted-foreground hover:text-foreground'
-                href={repo.html_url}
-                target='_blank'
-                rel='noopener noreferrer'
-                aria-label='View on GitHub' // Accessibility
-              >
-                <Github size={16} />
-              </ButtonLink>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>View on GitHub</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-
-      {/* Middle section: Description */}
-      {repo.description && (
-        <p className='text-sm text-muted-foreground mb-2 line-clamp-2'>
-          {' '}
-          {/* Limit description lines */}
-          {repo.description}
-        </p>
-      )}
-
-      {/* Bottom section: Homepage Link */}
-      {repo.homepage && (
-        <div className='flex items-center mt-1'>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a
-                href={repo.homepage}
-                target='_blank'
-                rel='noopener noreferrer'
-                aria-label='Repository Homepage'
-                className='flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline overflow-hidden text-ellipsis whitespace-nowrap'
-              >
-                <LinkIcon size={14} className='flex-shrink-0' />
-                <span className='truncate'>{repo.homepage}</span>
-              </a>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{repo.homepage}</p> {/* Show full URL in tooltip */}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      )}
-    </div>
-  )
-}
 
 export interface RepoSearchProps {
   repositories: RepoItem[]
@@ -153,7 +56,7 @@ export function RepoSearch({ repositories, loading, error, query }: RepoSearchPr
     <TooltipProvider delayDuration={300}>
       <div className='space-y-3'>
         {repositories.map((repo) => (
-          <RepoListItem key={repo.id} repo={repo} />
+          <RepositoryCard key={repo.id} repo={repo} />
         ))}
       </div>
     </TooltipProvider>

--- a/src/components/search/RepoSearch.tsx
+++ b/src/components/search/RepoSearch.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import type { GithubResponse } from '@/clients/github/api'
-import { Card, CardHeader } from '@/components/ui/card'
-import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
 import { RepositoryCard } from '@/components/search/RepositoryCard'
+import { Card, CardHeader } from '@/components/ui/card'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
 

--- a/src/components/search/RepoSearch.tsx
+++ b/src/components/search/RepoSearch.tsx
@@ -1,7 +1,8 @@
+import React from 'react'
 import type { GithubResponse } from '@/clients/github/api'
-import { RepositoryCard } from '@/components/search/RepositoryCard'
 import { Card, CardHeader } from '@/components/ui/card'
-import { TooltipProvider } from '@/components/ui/tooltip'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
+import { RepositoryCard } from '@/components/search/RepositoryCard'
 
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
 

--- a/src/components/search/RepoSearch.tsx
+++ b/src/components/search/RepoSearch.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import type { GithubResponse } from '@/clients/github/api'
-import { Card, CardHeader } from '@/components/ui/card'
-import { TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip' // Keep Tooltip related imports
 import { RepositoryCard } from '@/components/search/RepositoryCard'
+import { Card, CardHeader } from '@/components/ui/card'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
 

--- a/src/components/search/RepositoryCard.tsx
+++ b/src/components/search/RepositoryCard.tsx
@@ -72,5 +72,6 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
         </CardContent>
       )}
     </Card>
+    </a>
   )
 }

--- a/src/components/search/RepositoryCard.tsx
+++ b/src/components/search/RepositoryCard.tsx
@@ -1,9 +1,9 @@
 import { Star, Github, Link as LinkIcon } from 'lucide-react'
 import { type GithubResponse } from '@/clients/github/api'
+import { IconText } from '@/components/ui/IconText'
 import { ButtonLink } from '@/components/ui/button-link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { IconText } from '@/components/ui/IconText'
 
 // A reusable card for displaying GitHub repository search results or lists
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
@@ -18,60 +18,61 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
     repo.name,
   )}`
   return (
-    <a href={internalHref} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
+    <a
+      href={internalHref}
+      className='block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl'
+    >
       <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-150 w-full'>
         <CardHeader className='flex items-center justify-between'>
-          <CardTitle className='truncate'>
-            {repo.full_name}
-          </CardTitle>
+          <CardTitle className='truncate'>{repo.full_name}</CardTitle>
           <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
-            <IconText icon={<Star size={14} />} gap="gap-1" className="text-muted-foreground">
-            {repo.stargazers_count}
-          </IconText>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ButtonLink
-                variant='ghost'
-                size='icon'
-                href={repo.html_url}
-                aria-label='View on GitHub'
-              >
-                <Github size={16} />
-              </ButtonLink>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>View on GitHub</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </CardHeader>
-      {repo.description && (
-        <CardContent>
-          <p className='text-sm text-gray-600 dark:text-gray-400'>{repo.description}</p>
-        </CardContent>
-      )}
-      {repo.homepage && (
-        <CardContent>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconText
-                asChild
-                icon={<LinkIcon size={14} />}
-                gap="gap-1"
-                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                <a href={repo.homepage} target='_blank' rel='noopener noreferrer'>
-                  <span className='truncate'>{repo.homepage}</span>
-                </a>
-              </IconText>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{repo.homepage}</p>
-            </TooltipContent>
-          </Tooltip>
-        </CardContent>
-      )}
-    </Card>
+            <IconText icon={<Star size={14} />} gap='gap-1' className='text-muted-foreground'>
+              {repo.stargazers_count}
+            </IconText>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ButtonLink
+                  variant='ghost'
+                  size='icon'
+                  href={repo.html_url}
+                  aria-label='View on GitHub'
+                >
+                  <Github size={16} />
+                </ButtonLink>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>View on GitHub</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </CardHeader>
+        {repo.description && (
+          <CardContent>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>{repo.description}</p>
+          </CardContent>
+        )}
+        {repo.homepage && (
+          <CardContent>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconText
+                  asChild
+                  icon={<LinkIcon size={14} />}
+                  gap='gap-1'
+                  className='text-sm text-blue-600 dark:text-blue-400 hover:underline'
+                >
+                  <a href={repo.homepage} target='_blank' rel='noopener noreferrer'>
+                    <span className='truncate'>{repo.homepage}</span>
+                  </a>
+                </IconText>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{repo.homepage}</p>
+              </TooltipContent>
+            </Tooltip>
+          </CardContent>
+        )}
+      </Card>
     </a>
   )
 }

--- a/src/components/search/RepositoryCard.tsx
+++ b/src/components/search/RepositoryCard.tsx
@@ -18,18 +18,14 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
     repo.name,
   )}`
   return (
-    <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-150'>
-      <CardHeader className='flex items-center justify-between'>
-        <CardTitle className='truncate'>
-          <a
-            href={internalHref}
-            className='block font-semibold hover:underline text-gray-900 dark:text-gray-100 truncate'
-          >
+    <a href={internalHref} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
+      <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-150 w-full'>
+        <CardHeader className='flex items-center justify-between'>
+          <CardTitle className='truncate'>
             {repo.full_name}
-          </a>
-        </CardTitle>
-        <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
-          <IconText icon={<Star size={14} />} gap="gap-1" className="text-muted-foreground">
+          </CardTitle>
+          <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
+            <IconText icon={<Star size={14} />} gap="gap-1" className="text-muted-foreground">
             {repo.stargazers_count}
           </IconText>
           <Tooltip>

--- a/src/components/search/RepositoryCard.tsx
+++ b/src/components/search/RepositoryCard.tsx
@@ -1,9 +1,9 @@
 import { Star, Github, Link as LinkIcon } from 'lucide-react'
 import { type GithubResponse } from '@/clients/github/api'
-import { IconText } from '@/components/ui/IconText'
 import { ButtonLink } from '@/components/ui/button-link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { IconText } from '@/components/ui/IconText'
 
 // A reusable card for displaying GitHub repository search results or lists
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
@@ -18,61 +18,60 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
     repo.name,
   )}`
   return (
-    <a
-      href={internalHref}
-      className='block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl'
-    >
+    <a href={internalHref} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
       <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-150 w-full'>
         <CardHeader className='flex items-center justify-between'>
-          <CardTitle className='truncate'>{repo.full_name}</CardTitle>
+          <CardTitle className='truncate'>
+            {repo.full_name}
+          </CardTitle>
           <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
-            <IconText icon={<Star size={14} />} gap='gap-1' className='text-muted-foreground'>
-              {repo.stargazers_count}
-            </IconText>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ButtonLink
-                  variant='ghost'
-                  size='icon'
-                  href={repo.html_url}
-                  aria-label='View on GitHub'
-                >
-                  <Github size={16} />
-                </ButtonLink>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>View on GitHub</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        </CardHeader>
-        {repo.description && (
-          <CardContent>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>{repo.description}</p>
-          </CardContent>
-        )}
-        {repo.homepage && (
-          <CardContent>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <IconText
-                  asChild
-                  icon={<LinkIcon size={14} />}
-                  gap='gap-1'
-                  className='text-sm text-blue-600 dark:text-blue-400 hover:underline'
-                >
-                  <a href={repo.homepage} target='_blank' rel='noopener noreferrer'>
-                    <span className='truncate'>{repo.homepage}</span>
-                  </a>
-                </IconText>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>{repo.homepage}</p>
-              </TooltipContent>
-            </Tooltip>
-          </CardContent>
-        )}
-      </Card>
+            <IconText icon={<Star size={14} />} gap="gap-1" className="text-muted-foreground">
+            {repo.stargazers_count}
+          </IconText>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ButtonLink
+                variant='ghost'
+                size='icon'
+                href={repo.html_url}
+                aria-label='View on GitHub'
+              >
+                <Github size={16} />
+              </ButtonLink>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>View on GitHub</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+      {repo.description && (
+        <CardContent>
+          <p className='text-sm text-gray-600 dark:text-gray-400'>{repo.description}</p>
+        </CardContent>
+      )}
+      {repo.homepage && (
+        <CardContent>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <IconText
+                asChild
+                icon={<LinkIcon size={14} />}
+                gap="gap-1"
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                <a href={repo.homepage} target='_blank' rel='noopener noreferrer'>
+                  <span className='truncate'>{repo.homepage}</span>
+                </a>
+              </IconText>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{repo.homepage}</p>
+            </TooltipContent>
+          </Tooltip>
+        </CardContent>
+      )}
+    </Card>
     </a>
   )
 }

--- a/src/components/search/RepositoryCard.tsx
+++ b/src/components/search/RepositoryCard.tsx
@@ -3,6 +3,7 @@ import { type GithubResponse } from '@/clients/github/api'
 import { ButtonLink } from '@/components/ui/button-link'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { IconText } from '@/components/ui/IconText'
 
 // A reusable card for displaying GitHub repository search results or lists
 type RepoItem = GithubResponse['searchRepositories']['items'][number]
@@ -28,9 +29,9 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
           </a>
         </CardTitle>
         <div className='flex items-center gap-2 text-sm whitespace-nowrap'>
-          <span className='flex items-center gap-1 text-muted-foreground'>
-            <Star size={14} /> {repo.stargazers_count}
-          </span>
+          <IconText icon={<Star size={14} />} gap="gap-1" className="text-muted-foreground">
+            {repo.stargazers_count}
+          </IconText>
           <Tooltip>
             <TooltipTrigger asChild>
               <ButtonLink
@@ -57,15 +58,16 @@ export function RepositoryCard({ repo }: RepositoryCardProps) {
         <CardContent>
           <Tooltip>
             <TooltipTrigger asChild>
-              <a
-                href={repo.homepage}
-                target='_blank'
-                rel='noopener noreferrer'
-                className='flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline'
+              <IconText
+                asChild
+                icon={<LinkIcon size={14} />}
+                gap="gap-1"
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
               >
-                <LinkIcon size={14} />
-                <span className='truncate'>{repo.homepage}</span>
-              </a>
+                <a href={repo.homepage} target='_blank' rel='noopener noreferrer'>
+                  <span className='truncate'>{repo.homepage}</span>
+                </a>
+              </IconText>
             </TooltipTrigger>
             <TooltipContent>
               <p>{repo.homepage}</p>

--- a/src/components/search/UserCard.tsx
+++ b/src/components/search/UserCard.tsx
@@ -30,21 +30,21 @@ function TypeIcon({ type }: { type: UserItem['type'] }) {
 export function UserCard({ user }: UserCardProps) {
   const href = `/user?u=${encodeURIComponent(user.login)}`
   return (
-    <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors'>
-      <CardHeader className='flex items-center justify-between p-2'>
-        <div className='flex items-center gap-3 overflow-hidden'>
-          <Avatar className='h-8 w-8 flex-shrink-0'>
-            <AvatarImage src={user.avatar_url} alt={`${user.login} avatar`} />
-            <AvatarFallback>{user.login.slice(0, 2).toUpperCase()}</AvatarFallback>
-          </Avatar>
-          <CardTitle className='truncate'>
-            <a href={href} className='block hover:underline'>
+    <a href={href} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
+      <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors w-full'>
+        <CardHeader className='flex items-center justify-between p-2'>
+          <div className='flex items-center gap-3 overflow-hidden'>
+            <Avatar className='h-8 w-8 flex-shrink-0'>
+              <AvatarImage src={user.avatar_url} alt={`${user.login} avatar`} />
+              <AvatarFallback>{user.login.slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <CardTitle className='truncate'>
               {user.login}
-            </a>
-          </CardTitle>
-        </div>
-        <TypeIcon type={user.type} />
-      </CardHeader>
-    </Card>
+            </CardTitle>
+          </div>
+          <TypeIcon type={user.type} />
+        </CardHeader>
+      </Card>
+    </a>
   )
 }

--- a/src/components/search/UserCard.tsx
+++ b/src/components/search/UserCard.tsx
@@ -30,7 +30,7 @@ function TypeIcon({ type }: { type: UserItem['type'] }) {
 export function UserCard({ user }: UserCardProps) {
   const href = `/user?u=${encodeURIComponent(user.login)}`
   return (
-    <a href={href} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
+    <a href={href} className='block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl'>
       <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors w-full'>
         <CardHeader className='flex items-center justify-between p-2'>
           <div className='flex items-center gap-3 overflow-hidden'>
@@ -38,9 +38,7 @@ export function UserCard({ user }: UserCardProps) {
               <AvatarImage src={user.avatar_url} alt={`${user.login} avatar`} />
               <AvatarFallback>{user.login.slice(0, 2).toUpperCase()}</AvatarFallback>
             </Avatar>
-            <CardTitle className='truncate'>
-              {user.login}
-            </CardTitle>
+            <CardTitle className='truncate'>{user.login}</CardTitle>
           </div>
           <TypeIcon type={user.type} />
         </CardHeader>

--- a/src/components/search/UserCard.tsx
+++ b/src/components/search/UserCard.tsx
@@ -30,7 +30,7 @@ function TypeIcon({ type }: { type: UserItem['type'] }) {
 export function UserCard({ user }: UserCardProps) {
   const href = `/user?u=${encodeURIComponent(user.login)}`
   return (
-    <a href={href} className='block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl'>
+    <a href={href} className="block focus:outline-none focus:ring-2 focus:ring-ring rounded-xl">
       <Card className='hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors w-full'>
         <CardHeader className='flex items-center justify-between p-2'>
           <div className='flex items-center gap-3 overflow-hidden'>
@@ -38,7 +38,9 @@ export function UserCard({ user }: UserCardProps) {
               <AvatarImage src={user.avatar_url} alt={`${user.login} avatar`} />
               <AvatarFallback>{user.login.slice(0, 2).toUpperCase()}</AvatarFallback>
             </Avatar>
-            <CardTitle className='truncate'>{user.login}</CardTitle>
+            <CardTitle className='truncate'>
+              {user.login}
+            </CardTitle>
           </div>
           <TypeIcon type={user.type} />
         </CardHeader>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -8,9 +8,9 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700",
-        success: "bg-green-50 text-green-700 border-green-200 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
-        warning: "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700",
-        danger: "bg-red-50 text-red-700 border-red-200 dark:bg-red-900 dark:text-red-300 dark:border-red-700",
+        success: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
+        warning: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700",
+        danger: "bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700",
         outline: "text-foreground", // Existing outline from initial request, can be refined if needed
       },
     },

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700",
+        success: "bg-green-50 text-green-700 border-green-200 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
+        warning: "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700",
+        danger: "bg-red-50 text-red-700 border-red-200 dark:bg-red-900 dark:text-red-300 dark:border-red-700",
+        outline: "text-foreground", // Existing outline from initial request, can be refined if needed
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant, className }))} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -3,25 +3,21 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  "inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default:
-          'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700',
-        success:
-          'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700',
-        warning:
-          'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700',
-        danger:
-          'bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700',
-        outline: 'text-foreground', // Existing outline from initial request, can be refined if needed
+        default: "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700",
+        success: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
+        warning: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700",
+        danger: "bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700",
+        outline: "text-foreground", // Existing outline from initial request, can be refined if needed
       },
     },
     defaultVariants: {
       variant: 'default',
     },
-  },
+  }
 )
 
 export interface BadgeProps
@@ -29,7 +25,9 @@ export interface BadgeProps
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant, className }))} {...props} />
+  return (
+    <div className={cn(badgeVariants({ variant, className }))} {...props} />
+  )
 }
 
 export { Badge, badgeVariants }

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -3,21 +3,25 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  'inline-flex items-center rounded-full border px-2 py-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
-        default: "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700",
-        success: "bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700",
-        warning: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700",
-        danger: "bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700",
-        outline: "text-foreground", // Existing outline from initial request, can be refined if needed
+        default:
+          'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700',
+        success:
+          'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-300 dark:border-green-700',
+        warning:
+          'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700',
+        danger:
+          'bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700',
+        outline: 'text-foreground', // Existing outline from initial request, can be refined if needed
       },
     },
     defaultVariants: {
       variant: 'default',
     },
-  }
+  },
 )
 
 export interface BadgeProps
@@ -25,9 +29,7 @@ export interface BadgeProps
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant, className }))} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant, className }))} {...props} />
 }
 
 export { Badge, badgeVariants }

--- a/src/components/ui/IconText.tsx
+++ b/src/components/ui/IconText.tsx
@@ -4,27 +4,27 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const iconTextVariants = cva(
-  "inline-flex items-center align-middle", // Base classes
+  'inline-flex items-center align-middle', // Base classes
   {
     variants: {
       iconPosition: {
-        left: "flex-row",
-        right: "flex-row-reverse",
+        left: 'flex-row',
+        right: 'flex-row-reverse',
       },
     },
     defaultVariants: {
-      iconPosition: "left",
+      iconPosition: 'left',
     },
-  }
+  },
 )
 
 export interface IconTextProps
   extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof iconTextVariants> {
-  icon: React.ReactNode;
-  gap?: string; // e.g., 'gap-1', 'gap-2', 'gap-0'
-  asChild?: boolean;
-  children?: React.ReactNode; // Added children here as it's part of the component's content
+  icon: React.ReactNode
+  gap?: string // e.g., 'gap-1', 'gap-2', 'gap-0'
+  asChild?: boolean
+  children?: React.ReactNode // Added children here as it's part of the component's content
 }
 
 function IconText({
@@ -38,48 +38,44 @@ function IconText({
 }: IconTextProps) {
   if (asChild) {
     if (React.Children.count(children) !== 1 || !React.isValidElement(children)) {
-      console.error("IconText with asChild expects a single React element child. Received:", children);
-      return <>{children}</>;
+      console.error(
+        'IconText with asChild expects a single React element child. Received:',
+        children,
+      )
+      return <>{children}</>
     }
     return (
       <Slot className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
         {React.cloneElement(children as React.ReactElement, {
-          children: (
-            iconPosition === 'right' ? (
+          children:
+            iconPosition === 'right' ?
               <>
                 {(children as React.ReactElement).props.children}
                 {icon}
               </>
-            ) : (
-              <>
+            : <>
                 {icon}
                 {(children as React.ReactElement).props.children}
-              </>
-            )
-          ),
+              </>,
         })}
       </Slot>
-    );
+    )
   }
 
   return (
-    <span
-      className={cn(iconTextVariants({ iconPosition, className }), gap)}
-      {...props}
-    >
-      {iconPosition === 'right' ? (
+    <span className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
+      {iconPosition === 'right' ?
         <>
           {children}
           {icon}
         </>
-      ) : (
-        <>
+      : <>
           {icon}
           {children}
         </>
-      )}
+      }
     </span>
-  );
+  )
 }
 
 export { IconText, iconTextVariants }

--- a/src/components/ui/IconText.tsx
+++ b/src/components/ui/IconText.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const iconTextVariants = cva(
+  "inline-flex items-center align-middle", // Base classes
+  {
+    variants: {
+      iconPosition: {
+        left: "flex-row",
+        right: "flex-row-reverse",
+      },
+    },
+    defaultVariants: {
+      iconPosition: "left",
+    },
+  }
+)
+
+export interface IconTextProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof iconTextVariants> {
+  icon: React.ReactNode;
+  gap?: string; // e.g., 'gap-1', 'gap-2', 'gap-0'
+  asChild?: boolean;
+  children?: React.ReactNode; // Added children here as it's part of the component's content
+}
+
+function IconText({
+  className,
+  icon,
+  iconPosition,
+  gap = 'gap-1.5', // Default gap
+  asChild = false,
+  children,
+  ...props
+}: IconTextProps) {
+  const Comp = asChild ? Slot : 'span';
+  return (
+    <Comp
+      className={cn(iconTextVariants({ iconPosition, className }), gap)}
+      {...props}
+    >
+      {icon}
+      {children}
+    </Comp>
+  );
+}
+
+export { IconText, iconTextVariants }

--- a/src/components/ui/IconText.tsx
+++ b/src/components/ui/IconText.tsx
@@ -4,27 +4,27 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const iconTextVariants = cva(
-  'inline-flex items-center align-middle', // Base classes
+  "inline-flex items-center align-middle", // Base classes
   {
     variants: {
       iconPosition: {
-        left: 'flex-row',
-        right: 'flex-row-reverse',
+        left: "flex-row",
+        right: "flex-row-reverse",
       },
     },
     defaultVariants: {
-      iconPosition: 'left',
+      iconPosition: "left",
     },
-  },
+  }
 )
 
 export interface IconTextProps
   extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof iconTextVariants> {
-  icon: React.ReactNode
-  gap?: string // e.g., 'gap-1', 'gap-2', 'gap-0'
-  asChild?: boolean
-  children?: React.ReactNode // Added children here as it's part of the component's content
+  icon: React.ReactNode;
+  gap?: string; // e.g., 'gap-1', 'gap-2', 'gap-0'
+  asChild?: boolean;
+  children?: React.ReactNode; // Added children here as it's part of the component's content
 }
 
 function IconText({
@@ -38,44 +38,52 @@ function IconText({
 }: IconTextProps) {
   if (asChild) {
     if (React.Children.count(children) !== 1 || !React.isValidElement(children)) {
-      console.error(
-        'IconText with asChild expects a single React element child. Received:',
-        children,
-      )
-      return <>{children}</>
+      console.error("IconText with asChild expects a single React element child. Received:", children);
+      return <>{children}</>;
     }
+
+    const childElement = children as React.ReactElement;
+    const grandchildren: React.ReactNode = childElement.props.children;
+
     return (
       <Slot className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
-        {React.cloneElement(children as React.ReactElement, {
-          children:
-            iconPosition === 'right' ?
+        {React.cloneElement(childElement, {
+          children: (
+            iconPosition === 'right' ? (
               <>
-                {(children as React.ReactElement).props.children}
+                {grandchildren}
                 {icon}
               </>
-            : <>
+            ) : (
+              <>
                 {icon}
-                {(children as React.ReactElement).props.children}
-              </>,
+                {grandchildren}
+              </>
+            )
+          ),
         })}
       </Slot>
-    )
+    );
   }
 
   return (
-    <span className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
-      {iconPosition === 'right' ?
+    <span
+      className={cn(iconTextVariants({ iconPosition, className }), gap)}
+      {...props}
+    >
+      {iconPosition === 'right' ? (
         <>
           {children}
           {icon}
         </>
-      : <>
+      ) : (
+        <>
           {icon}
           {children}
         </>
-      }
+      )}
     </span>
-  )
+  );
 }
 
 export { IconText, iconTextVariants }

--- a/src/components/ui/IconText.tsx
+++ b/src/components/ui/IconText.tsx
@@ -4,27 +4,27 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const iconTextVariants = cva(
-  "inline-flex items-center align-middle", // Base classes
+  'inline-flex items-center align-middle', // Base classes
   {
     variants: {
       iconPosition: {
-        left: "flex-row",
-        right: "flex-row-reverse",
+        left: 'flex-row',
+        right: 'flex-row-reverse',
       },
     },
     defaultVariants: {
-      iconPosition: "left",
+      iconPosition: 'left',
     },
-  }
+  },
 )
 
 export interface IconTextProps
   extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof iconTextVariants> {
-  icon: React.ReactNode;
-  gap?: string; // e.g., 'gap-1', 'gap-2', 'gap-0'
-  asChild?: boolean;
-  children?: React.ReactNode; // Added children here as it's part of the component's content
+  icon: React.ReactNode
+  gap?: string // e.g., 'gap-1', 'gap-2', 'gap-0'
+  asChild?: boolean
+  children?: React.ReactNode // Added children here as it's part of the component's content
 }
 
 function IconText({
@@ -38,52 +38,48 @@ function IconText({
 }: IconTextProps) {
   if (asChild) {
     if (React.Children.count(children) !== 1 || !React.isValidElement(children)) {
-      console.error("IconText with asChild expects a single React element child. Received:", children);
-      return <>{children}</>;
+      console.error(
+        'IconText with asChild expects a single React element child. Received:',
+        children,
+      )
+      return <>{children}</>
     }
 
-    const childElement = children as React.ReactElement;
-    const grandchildren: React.ReactNode = childElement.props.children;
+    const childElement = children as React.ReactElement<any>
+    const grandchildren: React.ReactNode = childElement.props.children
 
     return (
       <Slot className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
         {React.cloneElement(childElement, {
-          children: (
-            iconPosition === 'right' ? (
+          children:
+            iconPosition === 'right' ?
               <>
                 {grandchildren}
                 {icon}
               </>
-            ) : (
-              <>
+            : <>
                 {icon}
                 {grandchildren}
-              </>
-            )
-          ),
+              </>,
         })}
       </Slot>
-    );
+    )
   }
 
   return (
-    <span
-      className={cn(iconTextVariants({ iconPosition, className }), gap)}
-      {...props}
-    >
-      {iconPosition === 'right' ? (
+    <span className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
+      {iconPosition === 'right' ?
         <>
           {children}
           {icon}
         </>
-      ) : (
-        <>
+      : <>
           {icon}
           {children}
         </>
-      )}
+      }
     </span>
-  );
+  )
 }
 
 export { IconText, iconTextVariants }

--- a/src/components/ui/IconText.tsx
+++ b/src/components/ui/IconText.tsx
@@ -36,15 +36,49 @@ function IconText({
   children,
   ...props
 }: IconTextProps) {
-  const Comp = asChild ? Slot : 'span';
+  if (asChild) {
+    if (React.Children.count(children) !== 1 || !React.isValidElement(children)) {
+      console.error("IconText with asChild expects a single React element child. Received:", children);
+      return <>{children}</>;
+    }
+    return (
+      <Slot className={cn(iconTextVariants({ iconPosition, className }), gap)} {...props}>
+        {React.cloneElement(children as React.ReactElement, {
+          children: (
+            iconPosition === 'right' ? (
+              <>
+                {(children as React.ReactElement).props.children}
+                {icon}
+              </>
+            ) : (
+              <>
+                {icon}
+                {(children as React.ReactElement).props.children}
+              </>
+            )
+          ),
+        })}
+      </Slot>
+    );
+  }
+
   return (
-    <Comp
+    <span
       className={cn(iconTextVariants({ iconPosition, className }), gap)}
       {...props}
     >
-      {icon}
-      {children}
-    </Comp>
+      {iconPosition === 'right' ? (
+        <>
+          {children}
+          {icon}
+        </>
+      ) : (
+        <>
+          {icon}
+          {children}
+        </>
+      )}
+    </span>
   );
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,6 @@ import { HeroSection } from '@/components/layout/HeroSection'
 ---
 
 <Layout>
-  <HeroSection title='fknexe' subtitle='Just download a fucking exe from Github' />
+  <HeroSection title="fknexe" subtitle="Just download a fucking exe from Github" />
   <UserSearchForm client:load withLabel withSearchButton />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,6 @@ import { HeroSection } from '@/components/layout/HeroSection'
 ---
 
 <Layout>
-  <HeroSection title="fknexe" subtitle="Just download a fucking exe from Github" />
+  <HeroSection title='fknexe' subtitle='Just download a fucking exe from Github' />
   <UserSearchForm client:load withLabel withSearchButton />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,10 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import { UserSearchForm } from '@/components/SearchForm'
+import { HeroSection } from '@/components/layout/HeroSection'
 ---
 
 <Layout>
-  <article class='typography mb-8 text-center'>
-    <h1 class='mb-0'>fknexe</h1>
-    <h3 class='mt-0'>Just download a fucking exe from Github</h3>
-  </article>
+  <HeroSection title="fknexe" subtitle="Just download a fucking exe from Github" />
   <UserSearchForm client:load withLabel withSearchButton />
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import { SearchResults } from '@/components/search/SearchResults'
+import { PageContainer } from '@/components/layout/PageContainer'
+import { PageTitle } from '@/components/layout/PageTitle'
 ---
 
 <Layout>
-  <div class='container mx-auto p-4'>
-    <h1 class='text-2xl font-bold mb-6'>Search Results</h1>
+  <PageContainer>
+    <PageTitle>Search Results</PageTitle>
     <SearchResults client:load />
-  </div>
+  </PageContainer>
 </Layout>


### PR DESCRIPTION
This commit introduces several reusable layout components to improve consistency and reduce direct Tailwind CSS usage in page structures.

New Components:
- `PageContainer.tsx`: A generic container for page content with standard padding and centering.
- `PageTitle.tsx`: A component for rendering standardized page titles (H1).
- `HeroSection.tsx`: A component for displaying a hero section with a title and subtitle, initially used on the homepage.

Refactoring:
- `src/pages/search.astro` now uses `PageContainer` and `PageTitle`.
- `src/pages/index.astro` now uses `HeroSection`.
- `src/components/GithubClientTester.tsx` now uses `PageTitle`.

These changes contribute to a more modular and maintainable frontend structure.